### PR TITLE
add awscli option to creds subcommand

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -42,6 +42,7 @@ jobs:
           ./bin/federator creds --role-arn ${{ secrets.ASSUME_ROLE_ARN }}
           ./bin/federator creds --role-arn ${{ secrets.ASSUME_ROLE_ARN }} --region $ANOTHER_AWS_REGION
           ./bin/federator creds --role-arn ${{ secrets.ASSUME_ROLE_ARN }} --json
+          ./bin/federator creds --role-arn ${{ secrets.ASSUME_ROLE_ARN }} --awscli
           ./bin/federator trust-policy --arn arn:aws:iam::000000000000:user/myUser --external-id "test external id"
           ./bin/federator trust-policy --arn arn:aws:iam::000000000000:user/myUser --external-id "test external id" --json
           ./bin/federator trust-policy --account-id 000000000000 --external-id "test external id"

--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ The arguments that each subcommand can take are listed below with the subcommand
 
 #### Flags for the `creds` subcommand
 
-| Parameter       | Defaults            | Description                                                                                     |
-| --------------- | ------------------- | ----------------------------------------------------------------------------------------------- |
-| `--role-arn`    | --                  | The ARN of the role to assume                                                                   |
-| `--external-id` | "" (empty string)   | The external ID, if necessary, to be provided, it will be added to the trust policy if provided |
-| `--region`      | from the CLI config | The region to make the STS call against                                                         |
-| `--json`        | `false`             | Whether to print out the results in JSON or plain text                                          |
+| Parameter       | Defaults            | Description                                                                                             |
+| --------------- | ------------------- |---------------------------------------------------------------------------------------------------------|
+| `--role-arn`    | --                  | The ARN of the role to assume                                                                           |
+| `--external-id` | "" (empty string)   | The external ID, if necessary, to be provided, it will be added to the trust policy if provided         |
+| `--region`      | from the CLI config | The region to make the STS call against                                                                 |
+| `--profile`     | "" (empty string)   | The AWS shared credentials file profile name to use when assuming the role                              |
+| `--json`        | `false`             | Whether to print out the results in JSON or plain text                                                  |
+| `--awscli`      | `false`             | Whether to print out the results in AWSCLI formatted json or plain text. Takes precedence over `--json` |
 
 #### Flags for the `trust-policy` subcommand
 
@@ -68,6 +70,9 @@ federator link --role-arn arn:aws:iam::000000000000:role/someRole --external-id 
 # Use a regional STS endpoint different from the one configured with the CLI
 federator creds --role-arn arn:aws:iam::000000000000:role/someRole --region us-east-1
 
+# Use the 'assumer' profile to make the assume role call
+federator creds --role-arn arn:aws:iam::000000000000:role/someRole --region us-east-1 --profile assumer
+
 # Change the output to json
 federator link --role-arn arn:aws:iam::000000000000:role/someRole --json
 
@@ -76,6 +81,12 @@ federator trust-policy --account-id 000000000000
 
 # Output a trust policy for an IAM user with an external ID provided
 federator trust-policy --arn arn:aws:iam::000000000000:user/myUser --external-id "some external id"
+```
+
+```
+# in ~/.aws/credentials
+[assumer]
+credential_process = /path/to/bin/federator creds --role-arn arn:aws:iam::000000000000:role/someRole --region us-east-1 --awscli
 ```
 
 ## Development

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 
 		config = credsCmd.GetAWSConfig()
 
-		if !credsCmd.Parsed.OutputJSON {
+		if !credsCmd.Parsed.OutputJSON && !credsCmd.Parsed.OutputAwsCli {
 			fmt.Printf(
 				"Using AWS STS in region %s to get temporary credentials...\n",
 				config.Region,
@@ -89,7 +89,7 @@ func main() {
 			log.Fatalln(credsErr.Error())
 		}
 
-		utils.PrintCredsFromSTSResponse(creds, credsCmd.Parsed.OutputJSON)
+		utils.PrintCredsFromSTSResponse(creds, credsCmd.Parsed.OutputJSON, credsCmd.Parsed.OutputAwsCli)
 		os.Exit(0)
 		break
 	case "trust-policy":

--- a/models/creds_details.go
+++ b/models/creds_details.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-
 	"github.com/YashdalfTheGray/federator/constants"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 // CredsDetails holds all of the details we need to print
@@ -34,7 +33,7 @@ func NewCredsDetails(out *sts.AssumeRoleOutput) *CredsDetails {
 func (c CredsDetails) ToJSONString() (string, error) {
 	prettyJSON, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return string(prettyJSON), nil
@@ -47,4 +46,33 @@ func (c CredsDetails) ToString() string {
 	result += (FormatEnvVar(constants.EnvAWSSecretAccessKey, c.SecretAccessKey) + "\n")
 	result += (FormatEnvVar(constants.EnvAWSSessionToken, c.SessionToken) + "\n")
 	return result
+}
+
+// AwsCliCreds mirrors what we must do for use as a credential_process.
+// see: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+// and: https://github.com/aws/aws-sdk-go-v2/blob/b7d8e15425d2f86a0596e8d7db2e33bf382a21dd/credentials/processcreds/provider.go#L152
+type AwsCliCreds struct {
+	Version         int
+	AccessKeyID     string `json:"AccessKeyId"`
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      *time.Time
+}
+
+func NewAwsCliCreds(output *sts.AssumeRoleOutput) *AwsCliCreds {
+	return &AwsCliCreds{
+		Version:         1,
+		AccessKeyID:     *output.Credentials.AccessKeyId,
+		SecretAccessKey: *output.Credentials.SecretAccessKey,
+		SessionToken:    *output.Credentials.SessionToken,
+		Expiration:      output.Credentials.Expiration,
+	}
+}
+
+func (creds AwsCliCreds) ToJSONString() (string, error) {
+	uglyJson, err := json.Marshal(&creds)
+	if err != nil {
+		return "", err
+	}
+	return string(uglyJson), nil
 }

--- a/subcommands/creds.go
+++ b/subcommands/creds.go
@@ -14,7 +14,7 @@ import (
 // needed for the link subcommand to work properly.
 type CredsSubcommandParsedArgs struct {
 	RoleArn, ExternalID, Region, Profile string
-	OutputJSON                           bool
+	OutputJSON, OutputAwsCli             bool
 }
 
 // CredsSubcommand holds the parsed args, when populated as well as internal
@@ -70,6 +70,12 @@ func (cmd *CredsSubcommand) Setup() {
 		"json",
 		false,
 		"output results as JSON rather than plain text",
+	)
+	cmd.subcommand.BoolVar(
+		&cmd.Parsed.OutputAwsCli,
+		"awscli",
+		false,
+		"output results in JSON format suitable for use with credentials_process",
 	)
 }
 


### PR DESCRIPTION
this allows us to use federator as a credential_process within the context of an aws shared credentials file